### PR TITLE
Feat/style-primary-button

### DIFF
--- a/src/OnboardFlow/Footer/index.tsx
+++ b/src/OnboardFlow/Footer/index.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react'
-import { KeyboardAvoidingView, StyleProp, StyleSheet, ViewStyle } from 'react-native'
+import { KeyboardAvoidingView, StyleProp, StyleSheet, ViewStyle, TextStyle } from 'react-native'
 import { OnboardComponents } from '../index'
 import { PRIMARY_BUTTON_TEXT_DEFAULT, PRIMARY_BUTTON_TEXT_LAST_PAGE_DEFAULT } from '../constants'
 import { PageData } from '../types'
@@ -17,6 +17,8 @@ export interface FooterProps {
   setCanContinue?: (value: boolean) => void
   showFooter?: boolean
   showHeader?: boolean
+  primaryButtonStyle?: StyleProp<ViewStyle>,
+  primaryButtonTextStyle?: StyleProp<TextStyle>
   props?: any
 }
 
@@ -31,6 +33,8 @@ export const Footer: FC<FooterProps> = ({
   canContinue,
   setCanContinue,
   showFooter = true,
+  primaryButtonStyle,
+  primaryButtonTextStyle,
   ...props
 }) => {
   function getPrimaryButtonTitle() {
@@ -58,6 +62,8 @@ export const Footer: FC<FooterProps> = ({
         totalPages={totalPages}
         goToNextPage={goToNextPage}
         disabled={!canContinue}
+        style={primaryButtonStyle}
+        textStyle={primaryButtonTextStyle}
       />
     </KeyboardAvoidingView>
   )

--- a/src/OnboardFlow/components/PrimaryButton/index.tsx
+++ b/src/OnboardFlow/components/PrimaryButton/index.tsx
@@ -5,7 +5,6 @@ import {
   PRIMARY_BUTTON_TEXT_DEFAULT,
   VERTICAL_PADDING_DEFAULT,
 } from '../../constants'
-import { TextStyles } from '../../types'
 
 export interface PrimaryButtonProps {
   currentPage?: number
@@ -17,15 +16,12 @@ export interface PrimaryButtonProps {
   disabled?: boolean
 }
 
-export const PrimaryButton: FC<PrimaryButtonProps & TextStyles> = ({
-  currentPage,
+export const PrimaryButton: FC<PrimaryButtonProps> = ({
   goToNextPage,
   style,
-  totalPages,
   text = PRIMARY_BUTTON_TEXT_DEFAULT,
   textStyle,
   disabled = false,
-  ...props
 }) => {
   return (
     <TouchableOpacity

--- a/src/OnboardFlow/components/PrimaryButton/index.tsx
+++ b/src/OnboardFlow/components/PrimaryButton/index.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react'
-import { StyleSheet, Text, TouchableOpacity, ViewStyle } from 'react-native'
+import { StyleSheet, Text, TextStyle, TouchableOpacity, ViewStyle, StyleProp } from 'react-native'
 import {
   COLOR_BUTTON_DEFAULT,
   PRIMARY_BUTTON_TEXT_DEFAULT,
@@ -10,9 +10,10 @@ import { TextStyles } from '../../types'
 export interface PrimaryButtonProps {
   currentPage?: number
   goToNextPage: () => void
-  style?: ViewStyle
+  style?: StyleProp<ViewStyle>
   totalPages?: number
   text?: string
+  textStyle: StyleProp<TextStyle>
   disabled?: boolean
 }
 

--- a/src/OnboardFlow/index.tsx
+++ b/src/OnboardFlow/index.tsx
@@ -87,6 +87,8 @@ export const OnboardFlow: FC<OnboardFlowProps & TextStyles> = ({
   FooterComponent = Footer,
   PaginationComponent = DotPagination,
   PrimaryButtonComponent = PrimaryButton,
+  primaryButtonStyle,
+  primaryButtonTextStyle,
   SecondaryButtonComponent = SecondaryButton,
   primaryColor = COLOR_PRIMARY_DEFAULT,
   secondaryColor = COLOR_SECONDARY_DEFAULT,
@@ -323,6 +325,8 @@ export const OnboardFlow: FC<OnboardFlowProps & TextStyles> = ({
           canContinue={canContinueValue}
           setCanContinue={setCanContinueValue}
           showFooter={showFooter}
+          primaryButtonStyle={primaryButtonStyle}
+          primaryButtonTextStyle={primaryButtonTextStyle}
         />
       </SafeAreaView>
     </ImageBackground>

--- a/src/OnboardFlow/types/index.ts
+++ b/src/OnboardFlow/types/index.ts
@@ -74,6 +74,8 @@ export interface OnboardFlowProps {
   FooterComponent?: FC<FooterProps>
   PaginationComponent?: FC<PaginationProps>
   PrimaryButtonComponent?: FC<PrimaryButtonProps>
+  primaryButtonStyle?: ViewStyle
+  primaryButtonTextStyle?: StyleProp<TextStyle>
   SecondaryButtonComponent?: FC<SecondaryButtonProps>
   primaryColor?: string
   secondaryColor?: string


### PR DESCRIPTION
## Overview: What does this pull request change?

Allows passing style parameters to primary button.

addresses this issue:
- https://github.com/FrigadeHQ/react-native-onboard/issues/14

### Further Information and Comments

Removed some properties from `PrimaryButton` that were not being used

### Images

```ts
primaryButtonStyle={{
      backgroundColor: "#0ae8ce",
      borderWidth: 6,
      borderColor: "#ffffff",
}}
primaryButtonTextStyle={{
      color: "#000000",
      fontWeight: "100",
}}
```

<img src="https://github.com/FrigadeHQ/react-native-onboard/assets/16950868/3740e8fe-874a-4f90-9967-ccac42f514bb" width="25%">

```ts
primaryButtonStyle={{
      backgroundColor: "#e80a6a",
      borderColor: "#ffffff",
}}
      primaryButtonTextStyle={{
      color: "#ffe100",
      fontWeight: "900",
}}
```
<img src="https://github.com/FrigadeHQ/react-native-onboard/assets/16950868/658af4aa-fd88-42ee-9784-430748749c7f" width="25%">

